### PR TITLE
Add mark all as read for notifications

### DIFF
--- a/components/notifications/NotificationsCenter.tsx
+++ b/components/notifications/NotificationsCenter.tsx
@@ -2,13 +2,13 @@
 
 import React, { useState, useRef, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Bell, X, Trash2 } from "lucide-react";
+import { Bell, CheckCheck, X, Trash2 } from "lucide-react";
 import { useNotifications } from "@/context/NotificationContext";
 import { formatDistanceToNow } from "date-fns";
 
 export const NotificationsCenter: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false);
-  const { notifications, markAsRead, clearAll } = useNotifications();
+  const { notifications, markAsRead, markAllAsRead, clearAll } = useNotifications();
   const unreadCount = notifications.filter((n) => !n.read).length;
   const dropdownRef = useRef<HTMLDivElement>(null);
   const firstNotificationRef = useRef<HTMLDivElement>(null);
@@ -75,6 +75,17 @@ export const NotificationsCenter: React.FC = () => {
                   Notifications
                 </h3>
                 <div className="flex items-center gap-1">
+                  {unreadCount > 0 && (
+                    <button
+                      onClick={markAllAsRead}
+                      className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1.5 text-[10px] font-bold uppercase tracking-wider text-[#e8b84b] transition-colors hover:bg-[#e8b84b]/10 hover:text-[#f0c85a] focus:outline-none focus:ring-2 focus:ring-[#e8b84b]/30"
+                      title="Mark all as read"
+                      aria-label={`Mark all ${unreadCount} unread notifications as read`}
+                    >
+                      <CheckCheck className="h-3.5 w-3.5" />
+                      Read all
+                    </button>
+                  )}
                   {notifications.length > 0 && (
                     <button
                       onClick={clearAll}

--- a/context/NotificationContext.tsx
+++ b/context/NotificationContext.tsx
@@ -29,6 +29,7 @@ interface NotificationContextType {
   toasts: Notification[];
   addNotification: (type: NotificationType, message: string) => void;
   markAsRead: (id: string) => void;
+  markAllAsRead: () => void;
   removeToast: (id: string) => void;
   clearAll: () => void;
   preferences: NotificationPreferences;
@@ -144,6 +145,14 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({
     );
   }, []);
 
+  const markAllAsRead = useCallback(() => {
+    setNotifications((prev) =>
+      prev.map((notification) =>
+        notification.read ? notification : { ...notification, read: true },
+      ),
+    );
+  }, []);
+
   const clearAll = useCallback(() => {
     setNotifications([]);
   }, []);
@@ -162,6 +171,7 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({
         toasts,
         addNotification,
         markAsRead,
+        markAllAsRead,
         removeToast,
         clearAll,
         preferences,


### PR DESCRIPTION
## Summary
- Add markAllAsRead to NotificationContext for bulk notification read updates.
- Show a Read all action only when unread notifications exist.
- Preserve the existing one-by-one read behavior and clear-all action.

Closes #53

## Evidence / validation
- npm run lint exited 0 with existing warnings only, no errors
- npm run type-check
- npm run build
- git diff --check
- sensitive scan of changed files returned no account/payment/private-key markers

## Screenshot note
I could not attach a browser recording from this environment, but the implementation is scoped to components/notifications/NotificationsCenter.tsx and context/NotificationContext.tsx, with the production build passing.