### PR TITLE
a11y(wallet): add keyboard switcher controls

### DIFF
--- a/components/wallet/WalletSwitcher.tsx
+++ b/components/wallet/WalletSwitcher.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef, useEffect, useId, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   ChevronDown,
@@ -44,13 +44,38 @@ export default function WalletSwitcher({
   const [editName, setEditName] = useState("");
   const [newWalletName, setNewWalletName] = useState("");
   const [newWalletAddress, setNewWalletAddress] = useState("");
+  const [activeWalletIndex, setActiveWalletIndex] = useState(0);
+  const [shouldFocusActiveWallet, setShouldFocusActiveWallet] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const walletOptionRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const walletSwitcherId = useId();
+  const walletListboxId = `${walletSwitcherId}-wallet-listbox`;
+
+  const getInitialWalletIndex = useCallback(() => {
+    const selectedIndex = wallets.findIndex((wallet) => wallet.id === selectedWallet?.id);
+    return selectedIndex >= 0 ? selectedIndex : 0;
+  }, [selectedWallet?.id, wallets]);
+
+  const closeDropdown = useCallback((restoreFocus = false, resetTransientState = false) => {
+    setIsOpen(false);
+    if (resetTransientState) {
+      setIsAdding(false);
+      setEditingId(null);
+    }
+    setShouldFocusActiveWallet(false);
+
+    if (restoreFocus) {
+      requestAnimationFrame(() => triggerRef.current?.focus());
+    }
+  }, []);
 
   // Close dropdown when clicking outside
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
         setIsOpen(false);
+        setShouldFocusActiveWallet(false);
       }
     };
 
@@ -62,18 +87,121 @@ export default function WalletSwitcher({
   useEffect(() => {
     const handleEsc = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
-        setIsOpen(false);
-        setIsAdding(false);
-        setEditingId(null);
+        const shouldRestoreFocus =
+          !!dropdownRef.current && dropdownRef.current.contains(document.activeElement);
+        closeDropdown(shouldRestoreFocus, true);
       }
     };
     window.addEventListener("keydown", handleEsc);
     return () => window.removeEventListener("keydown", handleEsc);
-  }, []);
+  }, [closeDropdown]);
+
+  useEffect(() => {
+    if (wallets.length === 0) {
+      setActiveWalletIndex(0);
+      return;
+    }
+
+    setActiveWalletIndex((currentIndex) => Math.min(currentIndex, wallets.length - 1));
+  }, [wallets.length]);
+
+  useEffect(() => {
+    if (!isOpen || !shouldFocusActiveWallet || isAdding || editingId) return;
+
+    requestAnimationFrame(() => {
+      walletOptionRefs.current[activeWalletIndex]?.focus();
+      setShouldFocusActiveWallet(false);
+    });
+  }, [activeWalletIndex, editingId, isAdding, isOpen, shouldFocusActiveWallet]);
 
   const handleSelect = (id: string) => {
     selectWallet(id);
-    setIsOpen(false);
+    closeDropdown(true);
+  };
+
+  const toggleDropdown = () => {
+    setIsOpen((open) => {
+      const nextOpen = !open;
+
+      if (nextOpen) {
+        setActiveWalletIndex(getInitialWalletIndex());
+      } else {
+        setShouldFocusActiveWallet(false);
+      }
+
+      return nextOpen;
+    });
+  };
+
+  const openDropdownWithKeyboard = (index = getInitialWalletIndex()) => {
+    setIsOpen(true);
+    setActiveWalletIndex(index);
+    setShouldFocusActiveWallet(true);
+  };
+
+  const focusWalletAtIndex = (index: number) => {
+    if (wallets.length === 0) return;
+
+    const nextIndex = (index + wallets.length) % wallets.length;
+    setActiveWalletIndex(nextIndex);
+    setShouldFocusActiveWallet(true);
+  };
+
+  const handleTriggerKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      if (isOpen) {
+        closeDropdown(true);
+      } else {
+        openDropdownWithKeyboard();
+      }
+      return;
+    }
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      openDropdownWithKeyboard(getInitialWalletIndex());
+      return;
+    }
+
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      openDropdownWithKeyboard(wallets.length > 0 ? wallets.length - 1 : 0);
+    }
+  };
+
+  const handleWalletOptionKeyDown = (
+    e: React.KeyboardEvent<HTMLDivElement>,
+    index: number,
+    walletId: string
+  ) => {
+    if (e.target !== e.currentTarget) return;
+
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        focusWalletAtIndex(index + 1);
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        focusWalletAtIndex(index - 1);
+        break;
+      case "Home":
+        e.preventDefault();
+        focusWalletAtIndex(0);
+        break;
+      case "End":
+        e.preventDefault();
+        focusWalletAtIndex(wallets.length - 1);
+        break;
+      case "Enter":
+      case " ":
+        e.preventDefault();
+        handleSelect(walletId);
+        break;
+      default:
+        break;
+    }
   };
 
   const handleRemove = (e: React.MouseEvent, id: string) => {
@@ -138,14 +266,21 @@ export default function WalletSwitcher({
   if (variant === "minimal") {
     return (
       <button
-        onClick={() => setIsOpen(!isOpen)}
+        ref={triggerRef}
+        onClick={toggleDropdown}
+        onKeyDown={handleTriggerKeyDown}
+        aria-label={
+          selectedWallet
+            ? `Select wallet, current wallet ${selectedWallet.name}`
+            : "Select wallet"
+        }
         className={`flex items-center gap-2 px-3 py-2 rounded-xl bg-white/5 border border-white/10 hover:bg-white/10 transition-all ${className}`}
       >
-        <Wallet className="w-4 h-4 text-[#e8b84b]" />
+        <Wallet className="w-4 h-4 text-[#e8b84b]" aria-hidden="true" />
         <span className="text-sm text-white font-medium">
           {selectedWallet ? formatAddress(selectedWallet.address) : "Select Wallet"}
         </span>
-        <ChevronDown className={`w-4 h-4 text-[#7a8aaa] transition-transform ${isOpen ? "rotate-180" : ""}`} />
+        <ChevronDown className={`w-4 h-4 text-[#7a8aaa] transition-transform ${isOpen ? "rotate-180" : ""}`} aria-hidden="true" />
       </button>
     );
   }
@@ -154,8 +289,18 @@ export default function WalletSwitcher({
     <div ref={dropdownRef} className={`relative ${className}`}>
       {/* Trigger Button */}
       <button
-        onClick={() => setIsOpen(!isOpen)}
+        ref={triggerRef}
+        onClick={toggleDropdown}
+        onKeyDown={handleTriggerKeyDown}
         disabled={isLoading}
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
+        aria-controls={walletListboxId}
+        aria-label={
+          selectedWallet
+            ? `Select wallet, current wallet ${selectedWallet.name}`
+            : "Select wallet"
+        }
         className={`flex items-center gap-3 w-full text-left transition-all ${
           variant === "compact"
             ? "px-3 py-2 rounded-xl bg-white/5 border border-white/10 hover:bg-white/10"
@@ -163,7 +308,7 @@ export default function WalletSwitcher({
         }`}
       >
         <div className={`rounded-xl bg-[#e8b84b]/10 flex items-center justify-center ${variant === "compact" ? "w-8 h-8" : "w-12 h-12"}`}>
-          <Wallet className={`text-[#e8b84b] ${variant === "compact" ? "w-4 h-4" : "w-6 h-6"}`} />
+          <Wallet className={`text-[#e8b84b] ${variant === "compact" ? "w-4 h-4" : "w-6 h-6"}`} aria-hidden="true" />
         </div>
         
         <div className="flex-1 min-w-0">
@@ -174,7 +319,7 @@ export default function WalletSwitcher({
                   {selectedWallet.name}
                 </span>
                 {selectedWallet.isDefault && (
-                  <Star className="w-3 h-3 text-[#e8b84b] fill-[#e8b84b]" />
+                  <Star className="w-3 h-3 text-[#e8b84b] fill-[#e8b84b]" aria-hidden="true" />
                 )}
               </div>
               {showBalance && (
@@ -189,8 +334,8 @@ export default function WalletSwitcher({
         </div>
 
         <div className="flex items-center gap-2">
-          {isLoading && <RefreshCw className="w-4 h-4 text-[#7a8aaa] animate-spin" />}
-          <ChevronDown className={`w-5 h-5 text-[#7a8aaa] transition-transform ${isOpen ? "rotate-180" : ""}`} />
+          {isLoading && <RefreshCw className="w-4 h-4 text-[#7a8aaa] animate-spin" aria-hidden="true" />}
+          <ChevronDown className={`w-5 h-5 text-[#7a8aaa] transition-transform ${isOpen ? "rotate-180" : ""}`} aria-hidden="true" />
         </div>
       </button>
 
@@ -213,20 +358,36 @@ export default function WalletSwitcher({
                 <button
                   onClick={handleRefresh}
                   disabled={isLoading}
+                  aria-label="Refresh wallet balances"
                   className="p-1.5 hover:bg-white/5 rounded-lg transition-colors"
                   title="Refresh balances"
                 >
-                  <RefreshCw className={`w-4 h-4 text-[#7a8aaa] ${isLoading ? "animate-spin" : ""}`} />
+                  <RefreshCw className={`w-4 h-4 text-[#7a8aaa] ${isLoading ? "animate-spin" : ""}`} aria-hidden="true" />
                 </button>
               </div>
 
               {/* Wallet List */}
-              <div className="max-h-80 overflow-y-auto">
-                {wallets.map((wallet) => (
+              <div
+                id={walletListboxId}
+                role="listbox"
+                aria-label="Linked wallets"
+                className="max-h-80 overflow-y-auto"
+              >
+                {wallets.map((wallet, index) => (
                   <div
                     key={wallet.id}
+                    ref={(node) => {
+                      walletOptionRefs.current[index] = node;
+                    }}
+                    id={`${walletListboxId}-${wallet.id}`}
+                    role="option"
+                    aria-selected={selectedWallet?.id === wallet.id}
+                    aria-label={`${wallet.name}, ${formatAddress(wallet.address)}, ${wallet.balance.xlm} XLM${wallet.isDefault ? ", default wallet" : ""}`}
+                    tabIndex={activeWalletIndex === index ? 0 : -1}
                     onClick={() => handleSelect(wallet.id)}
-                    className={`px-4 py-3 flex items-center gap-3 cursor-pointer transition-colors hover:bg-white/[0.03] ${
+                    onFocus={() => setActiveWalletIndex(index)}
+                    onKeyDown={(e) => handleWalletOptionKeyDown(e, index, wallet.id)}
+                    className={`px-4 py-3 flex items-center gap-3 cursor-pointer transition-colors hover:bg-white/[0.03] focus:outline-none focus-visible:bg-white/[0.03] focus-visible:ring-1 focus-visible:ring-[#e8b84b]/70 ${
                       selectedWallet?.id === wallet.id ? "bg-[#e8b84b]/5" : ""
                     }`}
                   >
@@ -237,7 +398,7 @@ export default function WalletSwitcher({
                         : "border-white/20"
                     }`}>
                       {selectedWallet?.id === wallet.id && (
-                        <Check className="w-3 h-3 text-[#1a0f00]" />
+                        <Check className="w-3 h-3 text-[#1a0f00]" aria-hidden="true" />
                       )}
                     </div>
 
@@ -254,15 +415,17 @@ export default function WalletSwitcher({
                           />
                           <button
                             onClick={(e) => saveEdit(e, wallet.id)}
+                            aria-label={`Save name for ${wallet.name}`}
                             className="p-1 hover:bg-green-500/20 rounded text-green-400"
                           >
-                            <Check className="w-4 h-4" />
+                            <Check className="w-4 h-4" aria-hidden="true" />
                           </button>
                           <button
                             onClick={cancelEdit}
+                            aria-label={`Cancel editing ${wallet.name}`}
                             className="p-1 hover:bg-red-500/20 rounded text-red-400"
                           >
-                            <X className="w-4 h-4" />
+                            <X className="w-4 h-4" aria-hidden="true" />
                           </button>
                         </div>
                       ) : (
@@ -272,7 +435,7 @@ export default function WalletSwitcher({
                               {wallet.name}
                             </span>
                             {wallet.isDefault && (
-                              <Star className="w-3 h-3 text-[#e8b84b] fill-[#e8b84b]" />
+                              <Star className="w-3 h-3 text-[#e8b84b] fill-[#e8b84b]" aria-hidden="true" />
                             )}
                           </div>
                           <p className="text-xs text-[#7a8aaa]">
@@ -284,29 +447,32 @@ export default function WalletSwitcher({
 
                     {/* Actions */}
                     {editingId !== wallet.id && (
-                      <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 hover:opacity-100 transition-opacity">
+                      <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 hover:opacity-100 focus-within:opacity-100 transition-opacity">
                         <button
                           onClick={(e) => startEditing(e, wallet)}
+                          aria-label={`Edit ${wallet.name} name`}
                           className="p-1.5 hover:bg-white/10 rounded-lg text-[#7a8aaa] hover:text-white transition-colors"
                           title="Edit name"
                         >
-                          <Edit2 className="w-3.5 h-3.5" />
+                          <Edit2 className="w-3.5 h-3.5" aria-hidden="true" />
                         </button>
                         {!wallet.isDefault && (
                           <button
                             onClick={(e) => handleSetDefault(e, wallet.id)}
+                            aria-label={`Set ${wallet.name} as default wallet`}
                             className="p-1.5 hover:bg-[#e8b84b]/20 rounded-lg text-[#7a8aaa] hover:text-[#e8b84b] transition-colors"
                             title="Set as default"
                           >
-                            <Star className="w-3.5 h-3.5" />
+                            <Star className="w-3.5 h-3.5" aria-hidden="true" />
                           </button>
                         )}
                         <button
                           onClick={(e) => handleRemove(e, wallet.id)}
+                          aria-label={`Remove ${wallet.name}`}
                           className="p-1.5 hover:bg-red-500/20 rounded-lg text-[#7a8aaa] hover:text-red-400 transition-colors"
                           title="Remove wallet"
                         >
-                          <Trash2 className="w-3.5 h-3.5" />
+                          <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
                         </button>
                       </div>
                     )}
@@ -361,7 +527,7 @@ export default function WalletSwitcher({
                   onClick={() => setIsAdding(true)}
                   className="w-full px-4 py-3 flex items-center gap-2 text-[#e8b84b] hover:bg-[#e8b84b]/10 transition-colors border-t border-white/5"
                 >
-                  <Plus className="w-4 h-4" />
+                  <Plus className="w-4 h-4" aria-hidden="true" />
                   <span className="text-sm font-medium">Add New Wallet</span>
                 </button>
               )}


### PR DESCRIPTION
Summary:
- Add keyboard controls for opening, closing, navigating, and selecting wallets in WalletSwitcher.
- Add listbox semantics, roving focus, aria labels, and selected-state metadata for wallet options.
- Preserve the existing click, edit, remove, set-default, refresh, and add-wallet flows.

Validation:
- git diff --check

Closes #54
