### PR TITLE
Persist selected language preference

### DIFF
--- a/components/I18nProvider.tsx
+++ b/components/I18nProvider.tsx
@@ -6,6 +6,50 @@ import { initReactI18next } from 'react-i18next';
 import commonEn from '@/locales/en/common.json';
 import commonEs from '@/locales/es/common.json';
 
+const LANGUAGE_STORAGE_KEY = "stellarspend_language";
+const SUPPORTED_LANGUAGES = ["en", "es"] as const;
+type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+
+function normalizeLanguage(value?: string | null): SupportedLanguage | null {
+  if (!value) {
+    return null;
+  }
+
+  const languageCode = value.toLowerCase().split("-")[0];
+  return SUPPORTED_LANGUAGES.includes(languageCode as SupportedLanguage)
+    ? (languageCode as SupportedLanguage)
+    : null;
+}
+
+function getStartupLanguage(initialLanguage: string): SupportedLanguage {
+  const fallback = normalizeLanguage(initialLanguage) ?? "en";
+
+  if (typeof window === "undefined") {
+    return fallback;
+  }
+
+  try {
+    const savedLanguage = normalizeLanguage(
+      localStorage.getItem(LANGUAGE_STORAGE_KEY),
+    );
+
+    if (savedLanguage) {
+      return savedLanguage;
+    }
+  } catch {
+    // Continue to browser language detection when storage is unavailable.
+  }
+
+  const browserLanguages = navigator.languages?.length
+    ? navigator.languages
+    : [navigator.language];
+  const browserLanguage = browserLanguages
+    .map((lng) => normalizeLanguage(lng))
+    .find(Boolean);
+
+  return browserLanguage ?? fallback;
+}
+
 // Initialize i18next
 i18next.use(initReactI18next).init({
   resources: {
@@ -47,25 +91,23 @@ export const I18nProvider: React.FC<I18nProviderProps> = ({
   children,
   initialLanguage = "en",
 }) => {
-  const [language, setLanguage] = useState(() => {
-    // Initialize language from localStorage or default
-    if (typeof window !== 'undefined') {
-      return localStorage.getItem('stellarspend_language') || initialLanguage;
-    }
-    return initialLanguage;
-  });
+  const [language, setLanguage] = useState(() =>
+    getStartupLanguage(initialLanguage),
+  );
 
   useEffect(() => {
     // Set i18next language when language changes
     i18next.changeLanguage(language);
+    document.documentElement.lang = language;
   }, [language]);
 
   const changeLanguage = async (lng: string) => {
-    await i18next.changeLanguage(lng);
-    setLanguage(lng);
+    const nextLanguage = normalizeLanguage(lng) ?? "en";
+    await i18next.changeLanguage(nextLanguage);
+    setLanguage(nextLanguage);
 
     if (typeof window !== "undefined") {
-      localStorage.setItem("stellarspend_language", lng);
+      localStorage.setItem(LANGUAGE_STORAGE_KEY, nextLanguage);
     }
   };
 

--- a/components/settings/LanguageSelector.tsx
+++ b/components/settings/LanguageSelector.tsx
@@ -26,7 +26,6 @@ export const LanguageSelector: React.FC<LanguageSelectorProps> = ({
   className = "",
 }) => {
   const { language, changeLanguage } = useI18n();
-  const _currentLanguage = languages.find(l => l.code === language) || languages[0];
 
   const handleLanguageChange = async (lng: string) => {
     await changeLanguage(lng);


### PR DESCRIPTION
## Summary
- Persist the selected language through the existing changeLanguage path.
- Load a saved language on provider startup, otherwise default from the browser language before falling back to English.
- Normalize locale tags like es-MX to supported app languages and keep document.documentElement.lang in sync.
- Remove the unused current-language lookup from the selector.

Closes #57

## Evidence / validation
- 
pm run lint exited 0 with existing warnings only, no errors
- 
pm run type-check
- 
pm run build
- git diff --check
- sensitive scan of changed files returned no account/payment/private-key markers

## Notes
- The existing provider already wrote language changes to storage; this fills the missing startup/browser-language fallback path requested by the issue.