### PR TITLE
Add transaction result toasts

### DIFF
--- a/components/transactions/TransactionItem.tsx
+++ b/components/transactions/TransactionItem.tsx
@@ -7,6 +7,7 @@ import {
   ChevronRight,
 } from "lucide-react";
 import { Transaction } from "@/lib/api/client";
+import { useToast } from "@/components/ui/use-toast";
 
 interface TransactionItemProps {
   transaction: Transaction;
@@ -17,13 +18,28 @@ export default function TransactionItem({
   transaction,
   onOpenDrawer,
 }: TransactionItemProps) {
+  const { toast } = useToast();
   const operation = transaction.operations[0];
   const userAccount = "GDQD6A4P422X44QW6UXO6R6AOTHOV4C6A4P422X44QW6UXO6R6AOTHO";
   const isIncoming = operation?.to === userAccount;
+  const amount = operation?.amount
+    ? `${operation.amount} ${operation.asset_code ?? "XLM"}`
+    : "Network operation";
+
+  const handleOpenDrawer = () => {
+    onOpenDrawer(transaction);
+    toast({
+      title: transaction.successful
+        ? "Transaction completed"
+        : "Transaction failed",
+      description: `${transaction.memo || operation?.type || "Transaction"} • ${amount}`,
+      variant: transaction.successful ? "default" : "destructive",
+    });
+  };
 
   return (
     <tr
-      onClick={() => onOpenDrawer(transaction)}
+      onClick={handleOpenDrawer}
       className="hover:bg-white/3 cursor-pointer transition-all group relative border-l-2 border-transparent hover:border-l-[#e8b84b]"
     >
       {/* Operation Type */}

--- a/context/NotificationContext.tsx
+++ b/context/NotificationContext.tsx
@@ -39,6 +39,7 @@ export const NotificationContext = createContext<NotificationContextType | undef
 
 const STORAGE_KEY = "stellarspend_notifications";
 const PREFS_KEY = "stellarspend_notification_preferences";
+const TOAST_AUTO_DISMISS_MS = 4000;
 
 function loadNotifications(): Notification[] {
   if (typeof window === "undefined") {
@@ -130,7 +131,7 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({
 
         setTimeout(() => {
           removeToast(newNotification.id);
-        }, 5000);
+        }, TOAST_AUTO_DISMISS_MS);
       }
     },
     [preferences, removeToast],


### PR DESCRIPTION
## Summary
- Use the existing useToast hook when a transaction row is opened.
- Show a success toast for completed transactions and a destructive error toast for failed/reverted transactions.
- Include transaction memo/type and amount context in the toast copy.
- Set toast auto-dismiss timing to 4 seconds to match the issue requirement.

Closes #61

## Evidence / validation
- 
pm run lint exited 0 with existing warnings only, no errors
- 
pm run type-check
- 
pm run build
- git diff --check
- sensitive scan of changed files returned no account/payment/private-key markers

## Notes
- Reuses the existing components/ui/use-toast.tsx and components/notifications/Toast.tsx stack.