### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Report a reproducible problem in StellarSpend
+title: "Bug: "
+labels: bug
+assignees: ""
+---
+
+## Summary
+
+Describe the bug and the user-facing impact.
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+What should happen?
+
+## Actual Behavior
+
+What happened instead?
+
+## Screenshots or Recording
+
+Attach screenshots, a short recording, or console output when helpful.
+
+## Environment
+
+- Browser:
+- Device:
+- Operating system:
+- Wallet/network state, if relevant:
+
+## Additional Context
+
+Add links, logs, or other details that help reviewers reproduce the issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,33 @@
+---
+name: Feature request
+about: Suggest an improvement for StellarSpend
+title: "Feature: "
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+
+What user problem or product gap should this solve?
+
+## Proposed Solution
+
+Describe the desired behavior and where it should appear in the app.
+
+## Alternatives Considered
+
+List any simpler or different approaches that were considered.
+
+## Acceptance Criteria
+
+- [ ]
+- [ ]
+- [ ]
+
+## Screenshots or Mockups
+
+Attach screenshots, sketches, or references if the feature has a visual change.
+
+## Additional Context
+
+Add links, edge cases, or implementation notes that help contributors scope the work.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Summary
+
+- 
+
+## Related Issue
+
+Closes #
+
+## Screenshots or Recordings
+
+Add screenshots or recordings for UI changes, or write `Not applicable`.
+
+## Validation
+
+- [ ] Tests were added or updated when needed
+- [ ] `npm run lint`
+- [ ] `npm run type-check`
+- [ ] `npm run build`
+- [ ] CI checks are passing or linked below
+
+## CI Evidence
+
+Link to the passing CI run or include a screenshot of the checks.
+
+## Reviewer Notes
+
+Call out any migrations, follow-up work, or areas that deserve extra review.


### PR DESCRIPTION
## Summary
- Add bug report and feature request issue templates under .github/ISSUE_TEMPLATE.
- Add a repository pull request template with validation, screenshots, and CI evidence checklist items.
- Keep the templates lightweight Markdown files so GitHub presents them automatically for new issues and PRs.

Closes #65

## Evidence / validation
- 
pm run lint exited 0 with existing warnings only, no errors
- 
pm run type-check
- 
pm run build
- git diff --check
- sensitive scan of the new template files returned no account/payment/private-key markers

## Notes
- No app runtime behavior changed; this is limited to GitHub contribution templates.