### PR TITLE
Add transaction search filter

### DIFF
--- a/app/dashboard/transactions/page.tsx
+++ b/app/dashboard/transactions/page.tsx
@@ -4,7 +4,7 @@ import React, { useState } from "react";
 import TransactionDrawer from "@/components/transactions/TransactionDrawer";
 import TransactionList from "@/components/transactions/TransactionList";
 import CustomSelect from "@/components/ui/CustomSelect";
-import { Search, Filter, RefreshCw } from "lucide-react";
+import { Filter, RefreshCw } from "lucide-react";
 import { Transaction, FilterParams } from "@/lib/api/client";
 
 export default function TransactionsPage() {
@@ -14,7 +14,6 @@ export default function TransactionsPage() {
 
   // Filter state
   const [filters, setFilters] = useState<FilterParams>({});
-  const [searchTerm, setSearchTerm] = useState("");
   const [dateFrom, setDateFrom] = useState("");
   const [dateTo, setDateTo] = useState("");
   const [selectedAsset, setSelectedAsset] = useState("all");
@@ -27,10 +26,6 @@ export default function TransactionsPage() {
 
   const applyFilters = () => {
     const newFilters: FilterParams = {};
-
-    if (searchTerm.trim()) {
-      newFilters.search = searchTerm.trim();
-    }
 
     if (dateFrom) {
       newFilters.dateFrom = dateFrom;
@@ -53,7 +48,6 @@ export default function TransactionsPage() {
   };
 
   const clearFilters = () => {
-    setSearchTerm("");
     setDateFrom("");
     setDateTo("");
     setSelectedAsset("all");
@@ -62,7 +56,6 @@ export default function TransactionsPage() {
   };
 
   const hasActiveFilters =
-    searchTerm ||
     dateFrom ||
     dateTo ||
     selectedAsset !== "all" ||
@@ -103,22 +96,7 @@ export default function TransactionsPage() {
 
         {/* Filters & Search */}
         <div className="relative z-50 space-y-4">
-          <div className="flex flex-col sm:flex-row gap-4">
-            <div className="relative flex-1 group">
-              <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-[#7a8aaa] group-focus-within:text-[#e8b84b] transition-colors" />
-              <input
-                type="text"
-                placeholder="Search by hash, memo or address..."
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    applyFilters();
-                  }
-                }}
-                className="w-full pl-12 pr-4 py-3.5 bg-white/[0.02] border border-white/10 rounded-2xl focus:ring-2 focus:ring-[#e8b84b]/30 focus:border-[#e8b84b]/50 text-white placeholder-[#7a8aaa]/50 outline-none transition-all"
-              />
-            </div>
+          <div className="flex justify-end">
             <button
               onClick={() => setShowFilters(!showFilters)}
               className={`flex items-center gap-2 px-6 py-3.5 rounded-2xl font-bold transition-all uppercase tracking-widest text-[10px] ${

--- a/components/transactions/TransactionList.tsx
+++ b/components/transactions/TransactionList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useRef, useCallback, useState } from "react";
+import React, { useEffect, useRef, useCallback, useMemo, useState } from "react";
 import {
   fetchTransactions,
   Transaction,
@@ -8,7 +8,7 @@ import {
   PaginatedResponse,
 } from "@/lib/api/client";
 import TransactionItem from "./TransactionItem";
-import { ChevronRight } from "lucide-react";
+import { ChevronRight, Search, X } from "lucide-react";
 
 interface TransactionListProps {
   filters: FilterParams;
@@ -26,6 +26,24 @@ export default function TransactionList({
   const [total, setTotal] = useState(0);
   const observerTarget = useRef<HTMLDivElement>(null);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [debouncedSearchTerm, setDebouncedSearchTerm] = useState("");
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setDebouncedSearchTerm(searchTerm.trim());
+    }, 300);
+
+    return () => window.clearTimeout(timer);
+  }, [searchTerm]);
+
+  const effectiveFilters = useMemo(
+    () => ({
+      ...filters,
+      search: debouncedSearchTerm || filters.search,
+    }),
+    [debouncedSearchTerm, filters],
+  );
 
   // Reset pagination when filters change
   useEffect(() => {
@@ -33,7 +51,7 @@ export default function TransactionList({
     setPage(1);
     setHasMore(true);
     setLoading(true);
-  }, [filters]);
+  }, [filters, debouncedSearchTerm]);
 
   // Load transactions
   const loadTransactions = useCallback(
@@ -43,7 +61,7 @@ export default function TransactionList({
           setIsLoadingMore(true);
         }
         const response: PaginatedResponse<Transaction> =
-          await fetchTransactions(filters, pageNum, 10);
+          await fetchTransactions(effectiveFilters, pageNum, 10);
 
         if (isNewSearch) {
           setTransactions(response.data);
@@ -61,7 +79,7 @@ export default function TransactionList({
         setIsLoadingMore(false);
       }
     },
-    [filters],
+    [effectiveFilters],
   );
 
   // Initial load
@@ -103,11 +121,43 @@ export default function TransactionList({
     }
   };
 
+  const clearSearch = () => {
+    setSearchTerm("");
+    setDebouncedSearchTerm("");
+  };
+
   if (loading && transactions.length === 0) {
     return (
-      <div className="bg-white/[0.01] backdrop-blur-sm rounded-3xl border border-white/5 shadow-2xl shadow-black/50">
-        <div className="overflow-x-auto overflow-y-visible">
-          <table className="w-full text-left border-collapse">
+      <>
+        <div className="mb-4 rounded-2xl border border-white/10 bg-white/[0.02] p-3">
+          <label htmlFor="transaction-search" className="sr-only">
+            Search transactions
+          </label>
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-[#7a8aaa]" />
+            <input
+              id="transaction-search"
+              type="search"
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              placeholder="Search description, amount, or date..."
+              className="w-full rounded-xl border border-white/10 bg-white/[0.03] py-3 pl-11 pr-10 text-sm text-white outline-none transition-all placeholder:text-[#7a8aaa]/60 focus:border-[#e8b84b]/50 focus:ring-2 focus:ring-[#e8b84b]/20"
+            />
+            {searchTerm && (
+              <button
+                type="button"
+                onClick={clearSearch}
+                className="absolute right-3 top-1/2 -translate-y-1/2 rounded-lg p-1 text-[#7a8aaa] transition-colors hover:bg-white/10 hover:text-white"
+                aria-label="Clear transaction search"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            )}
+          </div>
+        </div>
+        <div className="bg-white/[0.01] backdrop-blur-sm rounded-3xl border border-white/5 shadow-2xl shadow-black/50">
+          <div className="overflow-x-auto overflow-y-visible">
+            <table className="w-full text-left border-collapse">
             <thead>
               <tr className="border-b border-white/5 bg-white/[0.02]">
                 <th className="px-8 py-5 text-[10px] font-black text-[#7a8aaa] uppercase tracking-[0.2em]">
@@ -160,28 +210,83 @@ export default function TransactionList({
                 </tr>
               ))}
             </tbody>
-          </table>
+            </table>
+          </div>
         </div>
-      </div>
+      </>
     );
   }
 
   if (transactions.length === 0) {
     return (
-      <div className="text-center py-16 flex flex-col items-center">
-        <div className="w-1 h-12 bg-linear-to-b from-[#e8b84b]/20 to-transparent mb-6" />
-        <p className="text-[#7a8aaa] text-[10px] font-bold uppercase tracking-[0.3em]">
-          No transactions found
-        </p>
-        <p className="text-[#7a8aaa]/60 text-xs mt-2">
-          Try adjusting your filters or search query
-        </p>
-      </div>
+      <>
+        <div className="mb-4 rounded-2xl border border-white/10 bg-white/[0.02] p-3">
+          <label htmlFor="transaction-search" className="sr-only">
+            Search transactions
+          </label>
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-[#7a8aaa]" />
+            <input
+              id="transaction-search"
+              type="search"
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              placeholder="Search description, amount, or date..."
+              className="w-full rounded-xl border border-white/10 bg-white/[0.03] py-3 pl-11 pr-10 text-sm text-white outline-none transition-all placeholder:text-[#7a8aaa]/60 focus:border-[#e8b84b]/50 focus:ring-2 focus:ring-[#e8b84b]/20"
+            />
+            {searchTerm && (
+              <button
+                type="button"
+                onClick={clearSearch}
+                className="absolute right-3 top-1/2 -translate-y-1/2 rounded-lg p-1 text-[#7a8aaa] transition-colors hover:bg-white/10 hover:text-white"
+                aria-label="Clear transaction search"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            )}
+          </div>
+        </div>
+        <div className="text-center py-16 flex flex-col items-center">
+          <div className="w-1 h-12 bg-linear-to-b from-[#e8b84b]/20 to-transparent mb-6" />
+          <p className="text-[#7a8aaa] text-[10px] font-bold uppercase tracking-[0.3em]">
+            No results found
+          </p>
+          <p className="text-[#7a8aaa]/60 text-xs mt-2">
+            Try a different description, amount, or date
+          </p>
+        </div>
+      </>
     );
   }
 
   return (
     <>
+      <div className="mb-4 rounded-2xl border border-white/10 bg-white/[0.02] p-3">
+        <label htmlFor="transaction-search" className="sr-only">
+          Search transactions
+        </label>
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-[#7a8aaa]" />
+          <input
+            id="transaction-search"
+            type="search"
+            value={searchTerm}
+            onChange={(event) => setSearchTerm(event.target.value)}
+            placeholder="Search description, amount, or date..."
+            className="w-full rounded-xl border border-white/10 bg-white/[0.03] py-3 pl-11 pr-10 text-sm text-white outline-none transition-all placeholder:text-[#7a8aaa]/60 focus:border-[#e8b84b]/50 focus:ring-2 focus:ring-[#e8b84b]/20"
+          />
+          {searchTerm && (
+            <button
+              type="button"
+              onClick={clearSearch}
+              className="absolute right-3 top-1/2 -translate-y-1/2 rounded-lg p-1 text-[#7a8aaa] transition-colors hover:bg-white/10 hover:text-white"
+              aria-label="Clear transaction search"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+      </div>
       <div className="bg-white/[0.01] backdrop-blur-sm rounded-3xl border border-white/5 shadow-2xl shadow-black/50">
         <div className="overflow-x-auto overflow-y-visible">
           <table className="w-full text-left border-collapse">

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -449,11 +449,32 @@ export async function fetchTransactions(
   // Apply search
   if (filters?.search) {
     const query = filters.search.toLowerCase();
-    filtered = filtered.filter(
-      (tx) =>
+    filtered = filtered.filter((tx) => {
+      const createdDate = new Date(tx.created_at);
+      const dateMatches = [
+        tx.created_at,
+        createdDate.toLocaleDateString(),
+        createdDate.toISOString().slice(0, 10),
+      ].some((dateValue) => dateValue.toLowerCase().includes(query));
+
+      const operationMatches = tx.operations.some((operation) =>
+        [
+          operation.amount,
+          operation.asset_code,
+          operation.type,
+          operation.from,
+          operation.to,
+        ].some((value) => value?.toLowerCase().includes(query)),
+      );
+
+      return (
         tx.memo.toLowerCase().includes(query) ||
-        tx.hash.toLowerCase().includes(query),
-    );
+        tx.hash.toLowerCase().includes(query) ||
+        tx.ledger.toString().includes(query) ||
+        dateMatches ||
+        operationMatches
+      );
+    });
   }
 
   // Sort by date descending


### PR DESCRIPTION
## Summary
- Add a debounced search input above TransactionList with a clear action and empty-results state.
- Search transactions by memo/description, hash, ledger, date, amount, asset, operation type, and wallet addresses.
- Move the page-level manual search out of the transactions page so the list owns the real-time search experience.

Closes #48

## Evidence / validation
- 
pm run lint exited 0 with existing warnings only, no errors
- 
pm run type-check
- 
pm run build
- git diff --check
- sensitive scan of changed files returned no account/payment/private-key markers

## Notes
- No payment or account details were added.