### PR TITLE
Add budget progress indicator

### DIFF
--- a/app/dashboard/budgets/page.tsx
+++ b/app/dashboard/budgets/page.tsx
@@ -13,8 +13,10 @@ import BudgetForm from "@/components/budgets/BudgetForm";
 interface BudgetFormData {
   name: string;
   amount: number;
+  spent: number;
   category: string;
   asset: 'XLM' | 'USDC' | 'EURC';
+  period: 'daily' | 'monthly' | 'quarterly';
   startDate: string;
   endDate: string;
 }

--- a/components/budgets/BudgetForm.tsx
+++ b/components/budgets/BudgetForm.tsx
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { useForm } from "@/hooks/useForm";
 import { useOffline } from "@/components/offline/OfflineProvider";
 import { Budget } from "@/lib/api/client";
+import { Progress } from "@/components/ui/progress";
 
 const budgetSchema = z
   .object({
@@ -16,6 +17,9 @@ const budgetSchema = z
       .number()
       .positive("Amount must be positive")
       .min(0.01, "Minimum amount is 0.01"),
+    spent: z.coerce
+      .number()
+      .min(0, "Spent amount cannot be negative"),
     category: z.string().min(1, "Category is required"),
     asset: z.enum(["XLM", "USDC", "EURC"], {
       message: "Please select a valid asset",
@@ -53,18 +57,33 @@ export default function BudgetForm({ onSubmit, onCancel, initialData, isEditing 
         handleSubmit,
         formState: { errors, isValid, isSubmitting },
         reset: _reset,
+        watch,
     } = useForm<BudgetFormData>({
         schema: budgetSchema,
         defaultValues: {
             name: initialData?.name || '',
             amount: initialData?.amount || 0,
+            spent: initialData?.spent || 0,
             category: initialData?.category || '',
             asset: initialData?.asset || 'XLM',
+            period: initialData?.period || 'monthly',
             startDate: initialData?.startDate || new Date().toISOString().split('T')[0],
             endDate: initialData?.endDate || defaultEndDate,
         },
         mode: 'onChange',
     });
+
+    const amount = Number(watch('amount')) || 0;
+    const spent = Number(watch('spent')) || 0;
+    const asset = watch('asset') || 'XLM';
+    const budgetProgress = amount > 0 ? Math.min((spent / amount) * 100, 100) : 0;
+    const progressColorClass =
+        budgetProgress >= 90
+            ? 'bg-red-500'
+            : budgetProgress >= 75
+                ? 'bg-yellow-500'
+                : 'bg-green-500';
+    const formattedProgress = Math.round(budgetProgress);
 
     return (
         <div className="w-full max-w-md p-6 bg-white dark:bg-gray-800 rounded-xl shadow-lg">
@@ -109,6 +128,42 @@ export default function BudgetForm({ onSubmit, onCancel, initialData, isEditing 
                     {errors.amount && (
                         <p id="amount-error" className="text-xs text-red-500 mt-1" role="alert">{errors.amount.message}</p>
                     )}
+                </div>
+
+                <div className="space-y-1">
+                    <label htmlFor="spent" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                        Amount Spent
+                    </label>
+                    <input
+                        id="spent"
+                        type="number"
+                        step="0.01"
+                        {...register('spent')}
+                        aria-invalid={errors.spent ? 'true' : 'false'}
+                        aria-describedby={errors.spent ? 'spent-error' : 'budget-progress-help'}
+                        className={`w-full px-4 py-2 border rounded-md focus:ring-2 focus:ring-blue-500 outline-none transition-colors ${errors.spent ? 'border-red-500 bg-red-50' : 'border-gray-300 dark:border-gray-600 dark:bg-gray-700'
+                            }`}
+                        placeholder="0.00"
+                    />
+                    {errors.spent && (
+                        <p id="spent-error" className="text-xs text-red-500 mt-1" role="alert">{errors.spent.message}</p>
+                    )}
+                </div>
+
+                <div className="space-y-2" id="budget-progress-help">
+                    <div className="flex items-center justify-between text-sm text-gray-700 dark:text-gray-300">
+                        <span>Budget used</span>
+                        <span className="font-medium">
+                            {formattedProgress}% ({spent.toFixed(2)} / {amount.toFixed(2)} {asset})
+                        </span>
+                    </div>
+                    <Progress
+                        value={budgetProgress}
+                        indicatorClassName={progressColorClass}
+                    />
+                    <p className="text-xs text-gray-500">
+                        Green below 75%, yellow from 75% to 90%, red above 90%.
+                    </p>
                 </div>
 
                 <div className="space-y-1">

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -3,14 +3,17 @@ import React from 'react'
 interface ProgressProps {
   value: number
   className?: string
+  indicatorClassName?: string
 }
 
-export function Progress({ value, className = '' }: ProgressProps) {
+export function Progress({ value, className = '', indicatorClassName = 'bg-primary' }: ProgressProps) {
+  const clampedValue = Math.min(Math.max(value, 0), 100)
+
   return (
     <div className={`relative h-4 w-full overflow-hidden rounded-full bg-secondary ${className}`}>
       <div
-        className="h-full w-full flex-1 bg-primary transition-all"
-        style={{ transform: `translateX(-${100 - value}%)` }}
+        className={`h-full w-full flex-1 transition-all ${indicatorClassName}`}
+        style={{ transform: `translateX(-${100 - clampedValue}%)` }}
       />
     </div>
   )

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -43,8 +43,10 @@ export interface Budget {
   id: string;
   name: string;
   amount: number;
+  spent: number;
   category: string;
   asset: "XLM" | "USDC" | "EURC";
+  period: "daily" | "monthly" | "quarterly";
   startDate: string;
   endDate: string;
   createdAt: string;
@@ -366,8 +368,10 @@ export const MOCK_BUDGETS: Budget[] = [
     id: "budget_1",
     name: "Monthly Groceries",
     amount: 500,
+    spent: 225,
     category: "food",
     asset: "USDC",
+    period: "monthly",
     startDate: "2024-06-01",
     endDate: "2024-06-30",
     createdAt: "2024-05-20T10:00:00Z",
@@ -377,8 +381,10 @@ export const MOCK_BUDGETS: Budget[] = [
     id: "budget_2",
     name: "Transportation",
     amount: 150,
+    spent: 138,
     category: "transport",
     asset: "XLM",
+    period: "monthly",
     startDate: "2024-06-01",
     endDate: "2024-06-30",
     createdAt: "2024-05-19T15:30:00Z",


### PR DESCRIPTION
## Summary

- Add an amount-spent field to `BudgetForm`.
- Show a live budget progress bar using the existing `Progress` component.
- Change progress color by usage threshold: green below 75%, yellow from 75% to 90%, and red above 90%.
- Clamp progress rendering to 100% while preserving the entered spent/amount display.

## Verification

- `npm run lint`
  - Passed with existing warnings only.
- `npm run type-check`
  - Passed.
- Browser verification on local dev server:
  - 50 / 100 shows `bg-green-500` and 50%.
  - 80 / 100 shows `bg-yellow-500` and 80%.
  - 95 / 100 shows `bg-red-500` and 95%.

## Notes

- Installed dependencies with `npm install --ignore-scripts` because the normal Cypress install path timed out in this environment.
- The repository already reports npm audit vulnerabilities; they are unrelated to this issue and were not changed.

Closes #50