### PR TITLE
feat(settings): default language from browser preference

### DIFF
--- a/components/I18nProvider.tsx
+++ b/components/I18nProvider.tsx
@@ -6,6 +6,27 @@ import { initReactI18next } from 'react-i18next';
 import commonEn from '@/locales/en/common.json';
 import commonEs from '@/locales/es/common.json';
 
+const LANGUAGE_STORAGE_KEY = "stellarspend_language";
+const SUPPORTED_LANGUAGES = ["en", "es"] as const;
+
+function normalizeLanguage(lng: string | null | undefined): string | null {
+  if (!lng) return null;
+  const shortCode = lng.toLowerCase().split("-")[0];
+  return SUPPORTED_LANGUAGES.includes(shortCode as (typeof SUPPORTED_LANGUAGES)[number])
+    ? shortCode
+    : null;
+}
+
+function detectBrowserLanguage(): string | null {
+  if (typeof window === "undefined") return null;
+  const candidates = [window.navigator.language, ...Array.from(window.navigator.languages ?? [])];
+  for (const candidate of candidates) {
+    const normalized = normalizeLanguage(candidate);
+    if (normalized) return normalized;
+  }
+  return null;
+}
+
 // Initialize i18next
 i18next.use(initReactI18next).init({
   resources: {
@@ -48,11 +69,15 @@ export const I18nProvider: React.FC<I18nProviderProps> = ({
   initialLanguage = "en",
 }) => {
   const [language, setLanguage] = useState(() => {
-    // Initialize language from localStorage or default
     if (typeof window !== 'undefined') {
-      return localStorage.getItem('stellarspend_language') || initialLanguage;
+      return (
+        normalizeLanguage(localStorage.getItem(LANGUAGE_STORAGE_KEY)) ||
+        detectBrowserLanguage() ||
+        normalizeLanguage(initialLanguage) ||
+        "en"
+      );
     }
-    return initialLanguage;
+    return normalizeLanguage(initialLanguage) || "en";
   });
 
   useEffect(() => {
@@ -65,7 +90,7 @@ export const I18nProvider: React.FC<I18nProviderProps> = ({
     setLanguage(lng);
 
     if (typeof window !== "undefined") {
-      localStorage.setItem("stellarspend_language", lng);
+      localStorage.setItem(LANGUAGE_STORAGE_KEY, lng);
     }
   };
 


### PR DESCRIPTION
## Summary
- keep the existing saved-language localStorage preference as the first choice
- default to the browser language when no saved preference exists
- normalize unsupported or regional language codes back to the supported app languages

Closes #57.

## Validation
- git diff --check

I could not run `npm run lint` or `npm run type-check` locally because `node_modules` is not installed in this checkout. I also could not capture the requested refresh recording without a runnable local app.