### PR TITLE
feat(offline): Add offline banner dismiss button

### DIFF
--- a/components/offline/OfflineBanner.tsx
+++ b/components/offline/OfflineBanner.tsx
@@ -1,16 +1,29 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
+import { usePathname } from 'next/navigation';
 import { useOffline } from './OfflineProvider';
-import { WifiOff } from 'lucide-react';
+import { WifiOff, X } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 
 export default function OfflineBanner() {
     const { isOnline } = useOffline();
+    const pathname = usePathname();
+    const [dismissed, setDismissed] = useState(false);
+
+    // Banner lives in the root layout, so reset the dismissal when the route or
+    // connectivity changes (compared during render) and it reappears on the next
+    // page while still offline.
+    const resetKey = `${pathname}:${isOnline}`;
+    const [lastResetKey, setLastResetKey] = useState(resetKey);
+    if (resetKey !== lastResetKey) {
+        setLastResetKey(resetKey);
+        setDismissed(false);
+    }
 
     return (
         <AnimatePresence>
-            {!isOnline && (
+            {!isOnline && !dismissed && (
                 <motion.div
                     initial={{ height: 0, opacity: 0 }}
                     animate={{ height: 'auto', opacity: 1 }}
@@ -18,9 +31,17 @@ export default function OfflineBanner() {
                     transition={{ duration: 0.3 }}
                     className="sticky top-0 z-50 w-full bg-amber-500 text-white py-2 px-4 shadow-md overflow-hidden"
                 >
-                    <div className="max-w-7xl mx-auto flex items-center justify-center space-x-3 text-sm font-medium">
+                    <div className="relative max-w-7xl mx-auto flex items-center justify-center space-x-3 px-8 text-sm font-medium">
                         <WifiOff className="w-4 h-4 animate-pulse" />
                         <span>You are currently offline. Some features may be unavailable, but your actions will be queued.</span>
+                        <button
+                            type="button"
+                            onClick={() => setDismissed(true)}
+                            aria-label="Dismiss offline notification"
+                            className="absolute right-0 top-1/2 -translate-y-1/2 p-1 rounded hover:bg-amber-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+                        >
+                            <X className="w-4 h-4" />
+                        </button>
                     </div>
                 </motion.div>
             )}


### PR DESCRIPTION
Adds a keyboard-accessible close button so users can hide the offline banner during extended offline periods.

- The banner is mounted in the root layout, so it persists across routes. Dismissal is tracked in local state and reset when the route or connectivity changes (compared during render), so it reappears on the next page or connectivity change while still offline.
- The close button is a native `<button>` with an aria-label and a visible focus ring, so it is fully keyboard accessible.

Closes #51

**Demo:** https://streamable.com/xtbhw4 — banner dismissed, then reappearing after a connectivity change.

**Note on CI:** `main` is already failing before this change — a pre-existing `any` in `components/offline/QueuedActions.tsx` (line 68) and a missing `retryQueuedActions` on the offline context type break lint/build. Both are unrelated to this PR; the `OfflineBanner.tsx` change itself passes lint and type-check.