### PR TITLE
feat: add at-rest encryption for wallet and queue data (#110)

### DIFF
--- a/components/offline/OfflineProvider.tsx
+++ b/components/offline/OfflineProvider.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import React, { createContext, useContext, useEffect, useState } from "react";
+import React, { createContext, useContext, useEffect, useState, useCallback } from "react";
+import {
+  saveEncrypted,
+  loadEncrypted,
+  loadPlaintext,
+  migrateToEncrypted,
+  detectPlaintextData,
+} from "../lib/crypto/localEncryption";
 
 /**
  * Represents a pending action that was queued while offline.
@@ -20,26 +27,64 @@ interface OfflineContextType {
   removeAction: (id: string) => void;
   retryQueuedActions: () => void;
   clearQueue: () => void;
+  isUnlocked: boolean;
+  unlockQueue: (passphrase: string) => Promise<boolean>;
 }
 
 const OfflineContext = createContext<OfflineContextType | undefined>(undefined);
 const QUEUE_STORAGE_KEY = "stellarspend_offline_queue";
 
-function loadQueue(): QueuedAction[] {
+// Shared passphrase reference - set by WalletContext
+let sharedPassphrase: string | null = null;
+
+export function setQueuePassphrase(passphrase: string) {
+  sharedPassphrase = passphrase;
+}
+
+export function clearQueuePassphrase() {
+  sharedPassphrase = null;
+}
+
+async function loadQueueData(passphrase?: string): Promise<QueuedAction[]> {
   if (typeof window === "undefined") {
     return [];
   }
 
-  const savedQueue = localStorage.getItem(QUEUE_STORAGE_KEY);
-  if (!savedQueue) {
-    return [];
+  // First, check if there's plaintext data that needs migration
+  const hasPlaintext = detectPlaintextData(QUEUE_STORAGE_KEY);
+
+  if (hasPlaintext && passphrase) {
+    const plaintextData = loadPlaintext<QueuedAction[]>(QUEUE_STORAGE_KEY);
+    if (plaintextData) {
+      await migrateToEncrypted(QUEUE_STORAGE_KEY, passphrase, plaintextData);
+      return plaintextData;
+    }
   }
 
-  try {
-    return JSON.parse(savedQueue) as QueuedAction[];
-  } catch (error) {
-    console.error("Failed to parse offline queue", error);
-    return [];
+  // Try to load encrypted data
+  if (passphrase) {
+    const encrypted = await loadEncrypted<QueuedAction[]>(QUEUE_STORAGE_KEY, passphrase);
+    if (encrypted) {
+      return encrypted;
+    }
+  }
+
+  // Fallback to plaintext
+  const plaintext = loadPlaintext<QueuedAction[]>(QUEUE_STORAGE_KEY);
+  return plaintext || [];
+}
+
+async function saveQueueData(data: QueuedAction[], passphrase?: string): Promise<void> {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  if (passphrase) {
+    await saveEncrypted(QUEUE_STORAGE_KEY, data, passphrase);
+    // Clear plaintext
+    localStorage.removeItem(QUEUE_STORAGE_KEY);
+  } else {
+    localStorage.setItem(QUEUE_STORAGE_KEY, JSON.stringify(data));
   }
 }
 
@@ -47,7 +92,20 @@ export function OfflineProvider({ children }: { children: React.ReactNode }) {
   const [isOnline, setIsOnline] = useState<boolean>(
     () => (typeof navigator !== "undefined" ? navigator.onLine : true),
   );
-  const [queuedActions, setQueuedActions] = useState<QueuedAction[]>(loadQueue);
+  const [queuedActions, setQueuedActions] = useState<QueuedAction[]>([]);
+  const [isUnlocked, setIsUnlocked] = useState(false);
+
+  const loadQueue = useCallback(async () => {
+    const data = await loadQueueData(sharedPassphrase || undefined);
+    setQueuedActions(data);
+    if (sharedPassphrase) {
+      setIsUnlocked(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadQueue();
+  }, [loadQueue]);
 
   useEffect(() => {
     const handleOnline = () => setIsOnline(true);
@@ -63,12 +121,25 @@ export function OfflineProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   useEffect(() => {
-    if (typeof window !== "undefined") {
-      localStorage.setItem(QUEUE_STORAGE_KEY, JSON.stringify(queuedActions));
-    }
+    const saveQueue = async () => {
+      if (queuedActions.length > 0 || localStorage.getItem(QUEUE_STORAGE_KEY)) {
+        await saveQueueData(queuedActions, sharedPassphrase || undefined);
+      }
+    };
+    saveQueue();
   }, [queuedActions]);
 
-  const queueAction = (type: string, description: string, data: unknown) => {
+  const unlockQueue = useCallback(async (passphrase: string): Promise<boolean> => {
+    try {
+      sharedPassphrase = passphrase;
+      await loadQueue();
+      return true;
+    } catch {
+      return false;
+    }
+  }, [loadQueue]);
+
+  const queueAction = useCallback((type: string, description: string, data: unknown) => {
     const newAction: QueuedAction = {
       id: Math.random().toString(36).substring(2, 9),
       type,
@@ -77,21 +148,23 @@ export function OfflineProvider({ children }: { children: React.ReactNode }) {
       timestamp: Date.now(),
     };
     setQueuedActions((prev) => [...prev, newAction]);
-  };
+  }, []);
 
-  const removeAction = (id: string) => {
+  const removeAction = useCallback((id: string) => {
     setQueuedActions((prev) => prev.filter((action) => action.id !== id));
-  };
+  }, []);
 
-  const retryQueuedActions = () => {
+  const retryQueuedActions = useCallback(() => {
     if (queuedActions.length === 0) {
       return;
     }
-
     setQueuedActions((prev) => [...prev]);
-  };
+  }, [queuedActions]);
 
-  const clearQueue = () => setQueuedActions([]);
+  const clearQueue = useCallback(() => {
+    setQueuedActions([]);
+    localStorage.removeItem(QUEUE_STORAGE_KEY);
+  }, []);
 
   return (
     <OfflineContext.Provider
@@ -102,6 +175,8 @@ export function OfflineProvider({ children }: { children: React.ReactNode }) {
         removeAction,
         retryQueuedActions,
         clearQueue,
+        isUnlocked,
+        unlockQueue,
       }}
     >
       {children}

--- a/components/offline/OfflineProvider.tsx
+++ b/components/offline/OfflineProvider.tsx
@@ -7,7 +7,7 @@ import {
   loadPlaintext,
   migrateToEncrypted,
   detectPlaintextData,
-} from "../lib/crypto/localEncryption";
+} from "../../lib/crypto/localEncryption";
 
 /**
  * Represents a pending action that was queued while offline.
@@ -195,3 +195,4 @@ export function useOffline() {
   }
   return context;
 }
+

--- a/components/offline/OfflineProvider.tsx
+++ b/components/offline/OfflineProvider.tsx
@@ -103,8 +103,12 @@ export function OfflineProvider({ children }: { children: React.ReactNode }) {
     }
   }, []);
 
+  // Fixed: Wrap loadQueue in an async init function
   useEffect(() => {
-    loadQueue();
+    const init = async () => {
+      await loadQueue();
+    };
+    init();
   }, [loadQueue]);
 
   useEffect(() => {

--- a/components/settings/EncryptionMigrationPrompt.tsx
+++ b/components/settings/EncryptionMigrationPrompt.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { useWalletContext } from "../../context/WalletContext";
+import { detectPlaintextData } from "../../lib/crypto/localEncryption";
+
+const WALLETS_STORAGE_KEY = "stellarspend_wallets";
+const QUEUE_STORAGE_KEY = "stellarspend_offline_queue";
+
+export function EncryptionMigrationPrompt() {
+  const { setPassphrase } = useWalletContext();
+  const [hasPlaintextData, setHasPlaintextData] = useState(false);
+  const [passphrase, setPassphraseInput] = useState("");
+  const [confirmPassphrase, setConfirmPassphrase] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    const hasWallets = detectPlaintextData(WALLETS_STORAGE_KEY);
+    const hasQueue = detectPlaintextData(QUEUE_STORAGE_KEY);
+    setHasPlaintextData(hasWallets || hasQueue);
+  }, []);
+
+  if (!hasPlaintextData) {
+    return null;
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (passphrase.length < 6) {
+      setError("Passphrase must be at least 6 characters");
+      return;
+    }
+
+    if (passphrase !== confirmPassphrase) {
+      setError("Passphrases do not match");
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      await setPassphrase(passphrase);
+      setHasPlaintextData(false);
+    } catch (err) {
+      setError("Failed to encrypt data. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-6">
+        <h2 className="text-2xl font-bold mb-2">Encrypt Your Data</h2>
+        <p className="text-gray-600 mb-4">
+          We found existing wallet data that needs to be encrypted.
+          Please set a passphrase to secure your data.
+        </p>
+        
+        <form onSubmit={handleSubmit}>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">
+              Passphrase (min 6 characters)
+            </label>
+            <input
+              type="password"
+              value={passphrase}
+              onChange={(e) => setPassphraseInput(e.target.value)}
+              className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="Enter passphrase"
+              disabled={isLoading}
+              autoFocus
+            />
+          </div>
+          
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">
+              Confirm Passphrase
+            </label>
+            <input
+              type="password"
+              value={confirmPassphrase}
+              onChange={(e) => setConfirmPassphrase(e.target.value)}
+              className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="Confirm passphrase"
+              disabled={isLoading}
+            />
+          </div>
+          
+          {error && (
+            <div className="mb-4 p-3 bg-red-100 text-red-700 rounded-lg text-sm">
+              {error}
+            </div>
+          )}
+          
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="w-full bg-blue-600 text-white py-2 rounded-lg hover:bg-blue-700 transition disabled:opacity-50"
+          >
+            {isLoading ? "Encrypting..." : "Encrypt My Data"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/components/settings/PassphraseSetup.tsx
+++ b/components/settings/PassphraseSetup.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import React, { useState } from "react";
+import { useWalletContext } from "../../context/WalletContext";
+import { useOffline } from "../offline/OfflineProvider";
+
+interface PassphraseSetupProps {
+  onComplete?: () => void;
+}
+
+export function PassphraseSetup({ onComplete }: PassphraseSetupProps) {
+  const { passphraseSet, setPassphrase, unlock, resetLocalData } = useWalletContext();
+  const { unlockQueue } = useOffline();
+  
+  const [mode, setMode] = useState<"set" | "unlock" | "reset">(() => {
+    if (passphraseSet) return "unlock";
+    return "set";
+  });
+  
+  const [passphrase, setPassphraseInput] = useState("");
+  const [confirmPassphrase, setConfirmPassphrase] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [showResetConfirm, setShowResetConfirm] = useState(false);
+
+  const handleSetPassphrase = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    
+    if (passphrase.length < 6) {
+      setError("Passphrase must be at least 6 characters");
+      return;
+    }
+    
+    if (passphrase !== confirmPassphrase) {
+      setError("Passphrases do not match");
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      await setPassphrase(passphrase);
+      await unlockQueue(passphrase);
+      setMode("unlock");
+      onComplete?.();
+    } catch (err) {
+      setError("Failed to set passphrase. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleUnlock = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setIsLoading(true);
+
+    try {
+      const success = await unlock(passphrase);
+      if (success) {
+        await unlockQueue(passphrase);
+        onComplete?.();
+      } else {
+        setError("Invalid passphrase. Please try again.");
+      }
+    } catch {
+      setError("Failed to unlock. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleReset = () => {
+    resetLocalData();
+    setPassphraseInput("");
+    setConfirmPassphrase("");
+    setError(null);
+    setMode("set");
+    setShowResetConfirm(false);
+  };
+
+  if (mode === "set") {
+    return (
+      <div className="max-w-md mx-auto p-6 bg-white rounded-lg shadow-md">
+        <h2 className="text-2xl font-bold mb-4">Set Up Encryption</h2>
+        <p className="text-gray-600 mb-4">
+          Set a passphrase to encrypt your wallet data and offline actions.
+          This passphrase is never stored anywhere.
+        </p>
+        
+        <form onSubmit={handleSetPassphrase}>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">
+              Passphrase
+            </label>
+            <input
+              type="password"
+              value={passphrase}
+              onChange={(e) => setPassphraseInput(e.target.value)}
+              className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="Enter passphrase (min 6 characters)"
+              disabled={isLoading}
+            />
+          </div>
+          
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">
+              Confirm Passphrase
+            </label>
+            <input
+              type="password"
+              value={confirmPassphrase}
+              onChange={(e) => setConfirmPassphrase(e.target.value)}
+              className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="Confirm passphrase"
+              disabled={isLoading}
+            />
+          </div>
+          
+          {error && (
+            <div className="mb-4 p-3 bg-red-100 text-red-700 rounded-lg">
+              {error}
+            </div>
+          )}
+          
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="w-full bg-blue-600 text-white py-2 rounded-lg hover:bg-blue-700 transition disabled:opacity-50"
+          >
+            {isLoading ? "Setting up..." : "Set Passphrase"}
+          </button>
+        </form>
+      </div>
+    );
+  }
+
+  if (mode === "unlock") {
+    return (
+      <div className="max-w-md mx-auto p-6 bg-white rounded-lg shadow-md">
+        <h2 className="text-2xl font-bold mb-4">Unlock Your Data</h2>
+        <p className="text-gray-600 mb-4">
+          Enter your passphrase to unlock your encrypted data.
+        </p>
+        
+        <form onSubmit={handleUnlock}>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">
+              Passphrase
+            </label>
+            <input
+              type="password"
+              value={passphrase}
+              onChange={(e) => setPassphraseInput(e.target.value)}
+              className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="Enter your passphrase"
+              disabled={isLoading}
+            />
+          </div>
+          
+          {error && (
+            <div className="mb-4 p-3 bg-red-100 text-red-700 rounded-lg">
+              {error}
+            </div>
+          )}
+          
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="w-full bg-blue-600 text-white py-2 rounded-lg hover:bg-blue-700 transition disabled:opacity-50"
+          >
+            {isLoading ? "Unlocking..." : "Unlock"}
+          </button>
+        </form>
+        
+        <div className="mt-4 text-center">
+          <button
+            onClick={() => setShowResetConfirm(true)}
+            className="text-sm text-gray-500 hover:text-red-600 transition"
+          >
+            Forgot passphrase? Reset local data
+          </button>
+        </div>
+        
+        {showResetConfirm && (
+          <div className="mt-4 p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
+            <p className="text-sm text-yellow-800 mb-3">
+              This will delete all encrypted local data. You can reconnect your wallets after resetting.
+            </p>
+            <div className="flex gap-2">
+              <button
+                onClick={handleReset}
+                className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition"
+              >
+                Confirm Reset
+              </button>
+              <button
+                onClick={() => setShowResetConfirm(false)}
+                className="px-4 py-2 bg-gray-300 text-gray-700 rounded-lg hover:bg-gray-400 transition"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/components/settings/index.ts
+++ b/components/settings/index.ts
@@ -1,0 +1,2 @@
+export { PassphraseSetup } from './PassphraseSetup';
+export { EncryptionMigrationPrompt } from './EncryptionMigrationPrompt';

--- a/context/WalletContext.tsx
+++ b/context/WalletContext.tsx
@@ -1,6 +1,17 @@
 "use client";
 
 import React, { createContext, useContext, useState, useEffect, useCallback } from "react";
+import {
+  saveEncrypted,
+  loadEncrypted,
+  loadPlaintext,
+  migrateToEncrypted,
+  detectPlaintextData,
+  isPassphraseSet,
+  setPassphraseSet,
+  resetEncryption,
+  STORAGE_KEYS,
+} from "../lib/crypto/localEncryption";
 
 export interface Wallet {
   id: string;
@@ -20,7 +31,9 @@ export interface WalletContextType {
   wallets: Wallet[];
   selectedWallet: Wallet | null;
   isLoading: boolean;
+  isUnlocked: boolean;
   error: string | null;
+  passphraseSet: boolean;
   addWallet: (wallet: Omit<Wallet, "id" | "createdAt">) => void;
   removeWallet: (id: string) => void;
   selectWallet: (id: string) => void;
@@ -28,6 +41,11 @@ export interface WalletContextType {
   updateWalletName: (id: string, name: string) => void;
   setDefaultWallet: (id: string) => void;
   refreshBalances: () => Promise<void>;
+  unlock: (passphrase: string) => Promise<boolean>;
+  setPassphrase: (passphrase: string) => Promise<void>;
+  changePassphrase: (oldPassphrase: string, newPassphrase: string) => Promise<boolean>;
+  resetLocalData: () => void;
+  lock: () => void;
 }
 
 const WalletContext = createContext<WalletContextType | undefined>(undefined);
@@ -81,75 +99,268 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
   const [wallets, setWallets] = useState<Wallet[]>([]);
   const [selectedWalletId, setSelectedWalletId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [isUnlocked, setIsUnlocked] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [passphraseSet, setPassphraseSetState] = useState(false);
+  const [sessionPassphrase, setSessionPassphrase] = useState<string | null>(null);
+
+  // Check if passphrase is set on mount
+  useEffect(() => {
+    setPassphraseSetState(isPassphraseSet());
+  }, []);
 
   // Load wallets from localStorage on mount
-  useEffect(() => {
-    const loadWallets = () => {
-      try {
-        const savedWallets = localStorage.getItem(WALLETS_STORAGE_KEY);
-        const savedSelectedId = localStorage.getItem(SELECTED_WALLET_KEY);
+  const loadWallets = useCallback(async (passphrase?: string) => {
+    try {
+      // First, check if there's plaintext data that needs migration
+      const hasPlaintextWallets = detectPlaintextData(WALLETS_STORAGE_KEY);
+      const hasPlaintextSelected = detectPlaintextData(SELECTED_WALLET_KEY);
 
-        if (savedWallets) {
-          const parsed = JSON.parse(savedWallets);
-          setWallets(parsed);
-          
-          // Restore selected wallet or select default
-          if (savedSelectedId && parsed.find((w: Wallet) => w.id === savedSelectedId)) {
-            setSelectedWalletId(savedSelectedId);
-          } else {
-            const defaultWallet = parsed.find((w: Wallet) => w.isDefault);
-            setSelectedWalletId(defaultWallet?.id || parsed[0]?.id || null);
+      // If passphrase is set and we have plaintext data, migrate it
+      if (passphrase && (hasPlaintextWallets || hasPlaintextSelected)) {
+        // Migrate wallets
+        if (hasPlaintextWallets) {
+          const plaintextWallets = loadPlaintext<Wallet[]>(WALLETS_STORAGE_KEY);
+          if (plaintextWallets) {
+            await migrateToEncrypted(WALLETS_STORAGE_KEY, passphrase, plaintextWallets);
           }
-        } else {
-          // Initialize with mock data if no wallets exist
-          setWallets(MOCK_WALLETS);
-          const defaultWallet = MOCK_WALLETS.find((w) => w.isDefault);
-          setSelectedWalletId(defaultWallet?.id || MOCK_WALLETS[0]?.id);
-          localStorage.setItem(WALLETS_STORAGE_KEY, JSON.stringify(MOCK_WALLETS));
-          localStorage.setItem(SELECTED_WALLET_KEY, defaultWallet?.id || MOCK_WALLETS[0]?.id);
         }
-      } catch (err) {
-        setError("Failed to load wallets");
-        console.error("Failed to load wallets:", err);
-      } finally {
-        setIsLoading(false);
+        // Migrate selected wallet ID
+        if (hasPlaintextSelected) {
+          const plaintextSelected = loadPlaintext<string>(SELECTED_WALLET_KEY);
+          if (plaintextSelected) {
+            await migrateToEncrypted(SELECTED_WALLET_KEY, passphrase, plaintextSelected);
+          }
+        }
+        setPassphraseSetState(true);
+        setPassphraseSet();
       }
-    };
 
-    loadWallets();
+      // Try to load encrypted data
+      let loadedWallets: Wallet[] | null = null;
+      let loadedSelectedId: string | null = null;
+
+      if (passphrase) {
+        loadedWallets = await loadEncrypted<Wallet[]>(WALLETS_STORAGE_KEY, passphrase);
+        loadedSelectedId = await loadEncrypted<string>(SELECTED_WALLET_KEY, passphrase);
+      }
+
+      // If no encrypted data, check plaintext
+      if (!loadedWallets) {
+        const plaintext = loadPlaintext<Wallet[]>(WALLETS_STORAGE_KEY);
+        if (plaintext) {
+          loadedWallets = plaintext;
+          // If we have plaintext but passphrase is provided, migrate
+          if (passphrase) {
+            await migrateToEncrypted(WALLETS_STORAGE_KEY, passphrase, plaintext);
+            const plaintextSelected = loadPlaintext<string>(SELECTED_WALLET_KEY);
+            if (plaintextSelected) {
+              await migrateToEncrypted(SELECTED_WALLET_KEY, passphrase, plaintextSelected);
+            }
+            setPassphraseSetState(true);
+            setPassphraseSet();
+          }
+        }
+      }
+
+      // If still no wallets, initialize with mock data
+      if (!loadedWallets) {
+        // If passphrase is set, encrypt mock data
+        if (passphrase) {
+          await saveEncrypted(WALLETS_STORAGE_KEY, MOCK_WALLETS, passphrase);
+          const defaultWallet = MOCK_WALLETS.find(w => w.isDefault);
+          if (defaultWallet) {
+            await saveEncrypted(SELECTED_WALLET_KEY, defaultWallet.id, passphrase);
+          }
+          setPassphraseSetState(true);
+          setPassphraseSet();
+        } else {
+          // Save plaintext mock data (will be migrated on first unlock)
+          localStorage.setItem(WALLETS_STORAGE_KEY, JSON.stringify(MOCK_WALLETS));
+          const defaultWallet = MOCK_WALLETS.find(w => w.isDefault);
+          if (defaultWallet) {
+            localStorage.setItem(SELECTED_WALLET_KEY, defaultWallet.id);
+          }
+        }
+        loadedWallets = MOCK_WALLETS;
+        loadedSelectedId = MOCK_WALLETS.find(w => w.isDefault)?.id || MOCK_WALLETS[0]?.id || null;
+      }
+
+      setWallets(loadedWallets);
+      
+      if (loadedSelectedId) {
+        setSelectedWalletId(loadedSelectedId);
+      } else {
+        const defaultWallet = loadedWallets.find(w => w.isDefault);
+        setSelectedWalletId(defaultWallet?.id || loadedWallets[0]?.id || null);
+      }
+
+      if (passphrase) {
+        setIsUnlocked(true);
+        setSessionPassphrase(passphrase);
+      }
+
+      setPassphraseSetState(isPassphraseSet());
+
+    } catch (err) {
+      setError("Failed to load wallets");
+      console.error("Failed to load wallets:", err);
+    } finally {
+      setIsLoading(false);
+    }
   }, []);
+
+  // Initial load
+  useEffect(() => {
+    const init = async () => {
+      setIsLoading(true);
+      await loadWallets();
+    };
+    init();
+  }, [loadWallets]);
 
   // Save wallets to localStorage whenever they change
   useEffect(() => {
-    if (!isLoading) {
-      localStorage.setItem(WALLETS_STORAGE_KEY, JSON.stringify(wallets));
-    }
-  }, [wallets, isLoading]);
+    const saveWallets = async () => {
+      if (!isLoading && wallets.length > 0 && sessionPassphrase) {
+        try {
+          await saveEncrypted(WALLETS_STORAGE_KEY, wallets, sessionPassphrase);
+        } catch (err) {
+          console.error("Failed to save wallets:", err);
+        }
+      }
+    };
+    saveWallets();
+  }, [wallets, isLoading, sessionPassphrase]);
 
   // Save selected wallet to localStorage
   useEffect(() => {
-    if (!isLoading && selectedWalletId) {
-      localStorage.setItem(SELECTED_WALLET_KEY, selectedWalletId);
+    const saveSelected = async () => {
+      if (!isLoading && selectedWalletId && sessionPassphrase) {
+        try {
+          await saveEncrypted(SELECTED_WALLET_KEY, selectedWalletId, sessionPassphrase);
+        } catch (err) {
+          console.error("Failed to save selected wallet:", err);
+        }
+      }
+    };
+    saveSelected();
+  }, [selectedWalletId, isLoading, sessionPassphrase]);
+
+  const unlock = useCallback(async (passphrase: string): Promise<boolean> => {
+    setIsLoading(true);
+    try {
+      await loadWallets(passphrase);
+      return true;
+    } catch (err) {
+      setError("Invalid passphrase");
+      console.error("Unlock failed:", err);
+      return false;
+    } finally {
+      setIsLoading(false);
     }
-  }, [selectedWalletId, isLoading]);
+  }, [loadWallets]);
+
+  const setPassphrase = useCallback(async (passphrase: string): Promise<void> => {
+    try {
+      // Migrate any existing plaintext data
+      const hasPlaintextWallets = detectPlaintextData(WALLETS_STORAGE_KEY);
+      const hasPlaintextSelected = detectPlaintextData(SELECTED_WALLET_KEY);
+
+      if (hasPlaintextWallets) {
+        const plaintextWallets = loadPlaintext<Wallet[]>(WALLETS_STORAGE_KEY);
+        if (plaintextWallets) {
+          await migrateToEncrypted(WALLETS_STORAGE_KEY, passphrase, plaintextWallets);
+        }
+      }
+      if (hasPlaintextSelected) {
+        const plaintextSelected = loadPlaintext<string>(SELECTED_WALLET_KEY);
+        if (plaintextSelected) {
+          await migrateToEncrypted(SELECTED_WALLET_KEY, passphrase, plaintextSelected);
+        }
+      }
+
+      // If no plaintext data, encrypt current state
+      if (!hasPlaintextWallets && wallets.length > 0) {
+        await saveEncrypted(WALLETS_STORAGE_KEY, wallets, passphrase);
+        if (selectedWalletId) {
+          await saveEncrypted(SELECTED_WALLET_KEY, selectedWalletId, passphrase);
+        }
+      }
+
+      setPassphraseSetState(true);
+      setPassphraseSet();
+      setSessionPassphrase(passphrase);
+      setIsUnlocked(true);
+      
+      // Clear any plaintext data
+      localStorage.removeItem(WALLETS_STORAGE_KEY);
+      localStorage.removeItem(SELECTED_WALLET_KEY);
+
+    } catch (err) {
+      setError("Failed to set passphrase");
+      console.error("Failed to set passphrase:", err);
+      throw err;
+    }
+  }, [wallets, selectedWalletId]);
+
+  const changePassphrase = useCallback(async (oldPassphrase: string, newPassphrase: string): Promise<boolean> => {
+    try {
+      // Verify old passphrase works
+      const testWallets = await loadEncrypted<Wallet[]>(WALLETS_STORAGE_KEY, oldPassphrase);
+      if (!testWallets) {
+        setError("Invalid current passphrase");
+        return false;
+      }
+
+      // Re-encrypt with new passphrase
+      await saveEncrypted(WALLETS_STORAGE_KEY, testWallets, newPassphrase);
+      
+      if (selectedWalletId) {
+        await saveEncrypted(SELECTED_WALLET_KEY, selectedWalletId, newPassphrase);
+      }
+
+      setSessionPassphrase(newPassphrase);
+      return true;
+    } catch (err) {
+      setError("Failed to change passphrase");
+      console.error("Failed to change passphrase:", err);
+      return false;
+    }
+  }, [selectedWalletId]);
+
+  const resetLocalData = useCallback(() => {
+    resetEncryption();
+    localStorage.removeItem(WALLETS_STORAGE_KEY);
+    localStorage.removeItem(SELECTED_WALLET_KEY);
+    setWallets([]);
+    setSelectedWalletId(null);
+    setSessionPassphrase(null);
+    setIsUnlocked(false);
+    setPassphraseSetState(false);
+    // Reload with mock data
+    loadWallets();
+  }, [loadWallets]);
+
+  const lock = useCallback(() => {
+    setIsUnlocked(false);
+    setSessionPassphrase(null);
+  }, []);
 
   const addWallet = useCallback((wallet: Omit<Wallet, "id" | "createdAt">) => {
     const newWallet: Wallet = {
       ...wallet,
-      id: `wallet_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+      id: wallet__,
       createdAt: Date.now(),
     };
 
     setWallets((prev) => {
-      // If this is the first wallet, make it default
       if (prev.length === 0) {
         newWallet.isDefault = true;
       }
       return [...prev, newWallet];
     });
 
-    // If no wallet is selected, select the new one
     setSelectedWalletId((prev) => prev || newWallet.id);
   }, []);
 
@@ -158,7 +369,6 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
       const walletToRemove = prev.find((w) => w.id === id);
       const remaining = prev.filter((w) => w.id !== id);
       
-      // If removing the default wallet, set a new default
       if (walletToRemove?.isDefault && remaining.length > 0) {
         remaining[0].isDefault = true;
       }
@@ -166,7 +376,6 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
       return remaining;
     });
 
-    // If removing the selected wallet, select another one
     setSelectedWalletId((prev) => {
       if (prev === id) {
         const remaining = wallets.filter((w) => w.id !== id);
@@ -207,11 +416,8 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
     setError(null);
     
     try {
-      // Simulate API call to fetch balances
       await new Promise((resolve) => setTimeout(resolve, 1000));
       
-      // In a real implementation, this would fetch from Stellar Horizon API
-      // For now, we'll simulate some balance changes
       setWallets((prev) =>
         prev.map((w) => ({
           ...w,
@@ -235,7 +441,9 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
     wallets,
     selectedWallet,
     isLoading,
+    isUnlocked,
     error,
+    passphraseSet,
     addWallet,
     removeWallet,
     selectWallet,
@@ -243,6 +451,11 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
     updateWalletName,
     setDefaultWallet,
     refreshBalances,
+    unlock,
+    setPassphrase,
+    changePassphrase,
+    resetLocalData,
+    lock,
   };
 
   return (

--- a/context/WalletContext.tsx
+++ b/context/WalletContext.tsx
@@ -349,7 +349,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
   const addWallet = useCallback((wallet: Omit<Wallet, "id" | "createdAt">) => {
     const newWallet: Wallet = {
       ...wallet,
-      id: wallet__,
+      id: crypto.randomUUID(),
       createdAt: Date.now(),
     };
 
@@ -471,3 +471,4 @@ export function useWalletContext() {
   }
   return context;
 }
+

--- a/context/WalletContext.tsx
+++ b/context/WalletContext.tsx
@@ -10,7 +10,6 @@ import {
   isPassphraseSet,
   setPassphraseSet,
   resetEncryption,
-  STORAGE_KEYS,
 } from "../lib/crypto/localEncryption";
 
 export interface Wallet {

--- a/lib/crypto/__tests__/localEncryption.test.ts
+++ b/lib/crypto/__tests__/localEncryption.test.ts
@@ -1,0 +1,50 @@
+import { 
+  encryptData, 
+  decryptData, 
+  generateSalt,
+  isPassphraseSet,
+  setPassphraseSet,
+  resetEncryption 
+} from '../localEncryption';
+
+describe('localEncryption', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('generateSalt returns a string', () => {
+    const salt = generateSalt();
+    expect(typeof salt).toBe('string');
+    expect(salt.length).toBe(32);
+  });
+
+  test('encryptData and decryptData work correctly', async () => {
+    const data = { test: 'hello world', number: 123 };
+    const passphrase = 'test-passphrase-123';
+    
+    const encrypted = await encryptData(data, passphrase);
+    expect(typeof encrypted).toBe('string');
+    expect(encrypted).not.toBe(JSON.stringify(data));
+    
+    const decrypted = await decryptData(encrypted, passphrase);
+    expect(decrypted).toEqual(data);
+  });
+
+  test('decryptData fails with wrong passphrase', async () => {
+    const data = { test: 'hello world' };
+    const passphrase = 'correct-passphrase';
+    const wrongPassphrase = 'wrong-passphrase';
+    
+    const encrypted = await encryptData(data, passphrase);
+    
+    await expect(decryptData(encrypted, wrongPassphrase)).rejects.toThrow();
+  });
+
+  test('passphrase set functions work', () => {
+    expect(isPassphraseSet()).toBe(false);
+    setPassphraseSet();
+    expect(isPassphraseSet()).toBe(true);
+    resetEncryption();
+    expect(isPassphraseSet()).toBe(false);
+  });
+});

--- a/lib/crypto/localEncryption.ts
+++ b/lib/crypto/localEncryption.ts
@@ -1,0 +1,250 @@
+/**
+ * Local encryption utility using WebCrypto API
+ * Uses PBKDF2 for key derivation and AES-GCM for encryption
+ */
+
+export interface EncryptionConfig {
+  passphrase: string;
+  salt?: string;
+}
+
+const SALT_LENGTH = 16;
+const IV_LENGTH = 12;
+const KEY_LENGTH = 256;
+const ITERATIONS = 100000;
+
+const STORAGE_KEYS = {
+  ENCRYPTED_PREFIX: 'stellarspend_encrypted_',
+  SALT_KEY: 'stellarspend_encryption_salt',
+  PASSPHRASE_SET: 'stellarspend_passphrase_set',
+} as const;
+
+/**
+ * Generate a random salt
+ */
+export function generateSalt(): string {
+  const array = new Uint8Array(SALT_LENGTH);
+  crypto.getRandomValues(array);
+  return Array.from(array).map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Derive an encryption key from a passphrase and salt
+ */
+async function deriveKey(passphrase: string, salt: string): Promise<CryptoKey> {
+  const encoder = new TextEncoder();
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(passphrase),
+    'PBKDF2',
+    false,
+    ['deriveKey']
+  );
+
+  return crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt: encoder.encode(salt),
+      iterations: ITERATIONS,
+      hash: 'SHA-256',
+    },
+    keyMaterial,
+    {
+      name: 'AES-GCM',
+      length: KEY_LENGTH,
+    },
+    false,
+    ['encrypt', 'decrypt']
+  );
+}
+
+/**
+ * Encrypt data with a passphrase
+ */
+export async function encryptData(data: unknown, passphrase: string): Promise<string> {
+  const salt = generateSalt();
+  const key = await deriveKey(passphrase, salt);
+
+  const encoder = new TextEncoder();
+  const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH));
+  const encodedData = encoder.encode(JSON.stringify(data));
+
+  const encrypted = await crypto.subtle.encrypt(
+    {
+      name: 'AES-GCM',
+      iv,
+    },
+    key,
+    encodedData
+  );
+
+  // Combine salt + iv + encrypted data, all as base64
+  const combined = new Uint8Array(salt.length + iv.length + encrypted.byteLength);
+  combined.set(new TextEncoder().encode(salt), 0);
+  combined.set(iv, salt.length);
+  combined.set(new Uint8Array(encrypted), salt.length + iv.length);
+
+  return btoa(String.fromCharCode(...combined));
+}
+
+/**
+ * Decrypt data with a passphrase
+ */
+export async function decryptData<T>(encryptedData: string, passphrase: string): Promise<T> {
+  const combined = Uint8Array.from(atob(encryptedData), c => c.charCodeAt(0));
+
+  const salt = new TextDecoder().decode(combined.slice(0, SALT_LENGTH));
+  const iv = combined.slice(SALT_LENGTH, SALT_LENGTH + IV_LENGTH);
+  const encrypted = combined.slice(SALT_LENGTH + IV_LENGTH);
+
+  const key = await deriveKey(passphrase, salt);
+
+  const decrypted = await crypto.subtle.decrypt(
+    {
+      name: 'AES-GCM',
+      iv,
+    },
+    key,
+    encrypted
+  );
+
+  const decoder = new TextDecoder();
+  return JSON.parse(decoder.decode(decrypted));
+}
+
+/**
+ * Save encrypted data to localStorage
+ */
+export async function saveEncrypted(key: string, data: unknown, passphrase: string): Promise<void> {
+  const encrypted = await encryptData(data, passphrase);
+  localStorage.setItem(STORAGE_KEYS.ENCRYPTED_PREFIX + key, encrypted);
+}
+
+/**
+ * Load and decrypt data from localStorage
+ */
+export async function loadEncrypted<T>(key: string, passphrase: string): Promise<T | null> {
+  const encrypted = localStorage.getItem(STORAGE_KEYS.ENCRYPTED_PREFIX + key);
+  if (!encrypted) return null;
+  try {
+    return await decryptData<T>(encrypted, passphrase);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if data is encrypted (vs plaintext)
+ */
+export function isEncrypted(key: string): boolean {
+  const data = localStorage.getItem(key);
+  if (!data) return false;
+  // Encrypted data starts with base64 characters and has length > 50
+  return data.length > 50 && /^[A-Za-z0-9+/=]+$/.test(data);
+}
+
+/**
+ * Save plaintext data (migration helper)
+ */
+export function savePlaintext(key: string, data: unknown): void {
+  localStorage.setItem(key, JSON.stringify(data));
+}
+
+/**
+ * Load plaintext data (migration helper)
+ */
+export function loadPlaintext<T>(key: string): T | null {
+  const data = localStorage.getItem(key);
+  if (!data) return null;
+  try {
+    return JSON.parse(data);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Remove stored data
+ */
+export function removeStoredData(key: string): void {
+  localStorage.removeItem(key);
+  localStorage.removeItem(STORAGE_KEYS.ENCRYPTED_PREFIX + key);
+}
+
+/**
+ * Check if passphrase is set
+ */
+export function isPassphraseSet(): boolean {
+  return localStorage.getItem(STORAGE_KEYS.PASSPHRASE_SET) === 'true';
+}
+
+/**
+ * Set passphrase flag
+ */
+export function setPassphraseSet(): void {
+  localStorage.setItem(STORAGE_KEYS.PASSPHRASE_SET, 'true');
+}
+
+/**
+ * Reset encryption (forgot passphrase recovery)
+ */
+export function resetEncryption(): void {
+  // Get all encrypted keys
+  const keys: string[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key && key.startsWith(STORAGE_KEYS.ENCRYPTED_PREFIX)) {
+      keys.push(key);
+    }
+  }
+  // Remove encrypted data
+  keys.forEach(key => localStorage.removeItem(key));
+  localStorage.removeItem(STORAGE_KEYS.SALT_KEY);
+  localStorage.removeItem(STORAGE_KEYS.PASSPHRASE_SET);
+}
+
+/**
+ * Check if data is encrypted vs plaintext by looking at the raw data
+ */
+export function detectPlaintextData(key: string): boolean {
+  const data = localStorage.getItem(key);
+  if (!data) return false;
+  // If it's plaintext, it should be valid JSON
+  try {
+    JSON.parse(data);
+    // If it parses as JSON and looks like our data structure (not encrypted)
+    // Encrypted data will fail JSON.parse or be a long base64 string
+    if (data.length > 100 && /^[A-Za-z0-9+/=]+$/.test(data.substring(0, 100))) {
+      return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Migrate plaintext data to encrypted
+ */
+export async function migrateToEncrypted(
+  key: string,
+  passphrase: string,
+  data?: unknown
+): Promise<boolean> {
+  // If data is provided, just save it encrypted
+  if (data !== undefined) {
+    await saveEncrypted(key, data, passphrase);
+    localStorage.removeItem(key);
+    return true;
+  }
+
+  // Otherwise, try to load plaintext data
+  const plaintext = loadPlaintext(key);
+  if (plaintext === null) {
+    return false;
+  }
+
+  await saveEncrypted(key, plaintext, passphrase);
+  localStorage.removeItem(key);
+  return true;
+}


### PR DESCRIPTION
## Encrypt sensitive wallet/queue data at rest

### Problem
Wallet data and queued actions are stored in plaintext in localStorage, exposing privacy/security risks especially on shared devices.

### Solution
Add at-rest encryption using a user-set passphrase with WebCrypto (PBKDF2/AES-GCM).

### What I Changed

**New Files:**
- `lib/crypto/localEncryption.ts` - Encryption utilities using Web Crypto API
- `components/settings/PassphraseSetup.tsx` - UI for passphrase setup/unlock/reset
- `components/settings/EncryptionMigrationPrompt.tsx` - Auto-migration prompt
- `lib/crypto/__tests__/localEncryption.test.ts` - Unit tests

**Modified Files:**
- `context/WalletContext.tsx` - Encrypted read/write for wallets
- `components/offline/OfflineProvider.tsx` - Encrypted read/write for offline queue

### Features
- ✅ User-set passphrase/PIN (not tied to any private key)
- ✅ PBKDF2 key derivation + AES-GCM encryption
- ✅ Session-based unlock (once per session)
- ✅ Migration from plaintext data on first load
- ✅ Forgot passphrase recovery (reset local data, reconnect wallets)
- ✅ Unit tests for encryption utilities

Closes #110